### PR TITLE
feat: add initial Helm chart structure with subcharts (messaging, dis…

### DIFF
--- a/deploy-helm.sh
+++ b/deploy-helm.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Display title
+echo "====================================="
+echo "   Microservices Deployment with Helm"
+echo "====================================="
+
+# Check if Minikube is running
+echo "Checking Minikube status..."
+if ! minikube status | grep -q "Running"; then
+  echo "Minikube is not running. Starting Minikube..."
+  minikube start
+else
+  echo "Minikube is already running."
+fi
+
+# Set namespace
+NAMESPACE="ticket-booking"
+minikube kubectl -- create namespace "$NAMESPACE" 2>/dev/null || echo "Namespace $NAMESPACE already exists"
+
+# Deploy Helm chart
+echo "====================================="
+echo "Deploying ticket-booking application..."
+echo "====================================="
+helm install ticket-booking ./helm/ticket-booking --namespace "$NAMESPACE" --create-namespace
+
+# Check deployment status
+echo "====================================="
+echo "     Checking Pods status          "
+echo "====================================="
+minikube kubectl -- get pods -n "$NAMESPACE"
+
+echo "====================================="
+echo "    Checking Services status       "
+echo "====================================="
+minikube kubectl -- get services -n "$NAMESPACE"
+
+echo "====================================="
+echo "     Deployment completed!         "
+echo "====================================="

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: discoveryserver/Dockerfile
-    image: ${DOCKER_USERNAME}/discovery-server:latest
+    image: sagiri2004/ticket-booking-discovery:latest
     networks:
       - microservice-networks
 
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       dockerfile: authenticationservice/Dockerfile
-    image: ${DOCKER_USERNAME}/authentication-service:latest
+    image: sagiri2004/ticket-booking-authentication:latest
     networks:
       - microservice-networks
 
@@ -21,7 +21,7 @@ services:
     build:
       context: .
       dockerfile: userservice/Dockerfile
-    image: ${DOCKER_USERNAME}/user-service:latest
+    image: sagiri2004/ticket-booking-user:latest
     networks:
       - microservice-networks
 
@@ -29,7 +29,7 @@ services:
     build:
       context: .
       dockerfile: apigateway/Dockerfile
-    image: ${DOCKER_USERNAME}/api-gateway:latest
+    image: sagiri2004/ticket-booking-gateway:latest
     networks:
       - microservice-networks
 
@@ -37,7 +37,7 @@ services:
     build:
       context: .
       dockerfile: ticketservice/Dockerfile
-    image: ${DOCKER_USERNAME}/ticket-service:latest
+    image: sagiri2004/ticket-booking-ticket:latest
     networks:
       - microservice-networks
 
@@ -45,7 +45,7 @@ services:
     build:
       context: .
       dockerfile: bookingservice/Dockerfile
-    image: ${DOCKER_USERNAME}/booking-gateway:latest
+    image: sagiri2004/ticket-booking-booking:latest
     networks:
       - microservice-networks
 
@@ -53,7 +53,7 @@ services:
     build:
       context: .
       dockerfile: testservice/Dockerfile
-    image: ${DOCKER_USERNAME}/test-service:latest
+    image: sagiri2004/ticket-booking-test:latest
     networks:
       - microservice-networks
 
@@ -61,9 +61,10 @@ services:
     build:
       context: .
       dockerfile: notificationservice/Dockerfile
-    image: ${DOCKER_USERNAME}/notification-service:latest
+    image: sagiri2004/ticket-booking-notification:latest
     networks:
       - microservice-networks
+
 networks:
   microservice-networks:
     driver: bridge

--- a/helm/ticket-booking/Chart.yaml
+++ b/helm/ticket-booking/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: ticket-booking
+description: A Helm chart for deploying the Ticket Booking application with microservices
+version: 0.1.0
+appVersion: "1.0.0"
+maintainers:
+  - name: Your Name
+    email: your.email@example.com
+dependencies:
+  - name: axon
+    version: 0.1.0
+    condition: axon.enabled
+  - name: databases
+    version: 0.1.0
+    condition: databases.enabled
+  - name: messaging
+    version: 0.1.0
+    condition: messaging.enabled
+  - name: discovery
+    version: 0.1.0
+    condition: discovery.enabled
+  - name: gateway
+    version: 0.1.0
+    condition: gateway.enabled
+  - name: services
+    version: 0.1.0
+    condition: services.enabled

--- a/helm/ticket-booking/charts/axon/Chart.yaml
+++ b/helm/ticket-booking/charts/axon/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: axon
+description: A Helm chart for deploying Axon Server
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ticket-booking/charts/axon/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/axon/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{/* Common labels */}} {{- define "axon.labels" -}} app: axon {{- end -}}
+
+{{/* Selector labels */}} {{- define "axon.selectorLabels" -}} app: axon {{- end -}}

--- a/helm/ticket-booking/charts/axon/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/axon/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: axon
+  labels: { { - include "axon.labels" . | nindent 4 } }
+spec:
+  replicas: { { .Values.replicas } }
+  selector:
+    matchLabels: { { - include "axon.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "axon.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: axon
+          image: { { .Values.image } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/axon/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/axon/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: axon
+  labels:
+    {{- include "axon.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: axon
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/axon/templates/service.yaml
+++ b/helm/ticket-booking/charts/axon/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: axon
+  labels: { { - include "axon.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "axon.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/axon/values.yaml
+++ b/helm/ticket-booking/charts/axon/values.yaml
@@ -1,0 +1,18 @@
+image: axoniq/axonserver:latest
+replicas: 1
+port: 8024
+resources:
+  requests:
+    cpu: "100m"
+    memory: "256Mi"
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+service:
+  type: ClusterIP
+  port: 8024
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/databases/Chart.yaml
+++ b/helm/ticket-booking/charts/databases/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: databases
+description: A Helm chart for deploying databases (MySQL, Redis)
+version: 0.1.0
+appVersion: "1.0.0"
+dependencies:
+  - name: mysql
+    version: 0.1.0
+    condition: mysql.enabled
+  - name: redis
+    version: 0.1.0
+    condition: redis.enabled

--- a/helm/ticket-booking/charts/databases/charts/mysql/Chart.yaml
+++ b/helm/ticket-booking/charts/databases/charts/mysql/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: mysql
+description: A Helm chart for deploying MySQL
+version: 0.1.0
+appVersion: "8.0"

--- a/helm/ticket-booking/charts/databases/charts/mysql/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/databases/charts/mysql/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{/* Common labels */}} {{- define "mysql.labels" -}} app: mysql {{- end -}}
+
+{{/* Selector labels */}} {{- define "mysql.selectorLabels" -}} app: mysql {{- end -}}

--- a/helm/ticket-booking/charts/databases/charts/mysql/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/databases/charts/mysql/templates/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  labels: { { - include "mysql.labels" . | nindent 4 } }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { { - include "mysql.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "mysql.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: mysql
+          image: { { .Values.image } }
+          ports:
+            - containerPort: { { .Values.port } }
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: { { .Values.rootPassword } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/databases/charts/mysql/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/databases/charts/mysql/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: mysql
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mysql
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/databases/charts/mysql/templates/service.yaml
+++ b/helm/ticket-booking/charts/databases/charts/mysql/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels: { { - include "mysql.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "mysql.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/databases/charts/mysql/values.yaml
+++ b/helm/ticket-booking/charts/databases/charts/mysql/values.yaml
@@ -1,0 +1,18 @@
+image: mysql:8.0
+port: 3306
+rootPassword: root
+resources:
+  requests:
+    cpu: 400m
+    memory: 384Mi
+  limits:
+    cpu: 800m
+    memory: 768Mi
+service:
+  type: ClusterIP
+  port: 3306
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/databases/charts/redis/Chart.yaml
+++ b/helm/ticket-booking/charts/databases/charts/redis/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: redis
+description: A Helm chart for deploying Redis
+version: 0.1.0
+appVersion: "6.2"

--- a/helm/ticket-booking/charts/databases/charts/redis/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/databases/charts/redis/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{/* Common labels */}} {{- define "redis.labels" -}} app: redis {{- end -}}
+
+{{/* Selector labels */}} {{- define "redis.selectorLabels" -}} app: redis {{- end -}}

--- a/helm/ticket-booking/charts/databases/charts/redis/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/databases/charts/redis/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels: { { - include "redis.labels" . | nindent 4 } }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { { - include "redis.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "redis.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: redis
+          image: { { .Values.image } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/databases/charts/redis/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/databases/charts/redis/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: redis
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: redis
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/databases/charts/redis/templates/service.yaml
+++ b/helm/ticket-booking/charts/databases/charts/redis/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels: { { - include "redis.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "redis.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/databases/charts/redis/values.yaml
+++ b/helm/ticket-booking/charts/databases/charts/redis/values.yaml
@@ -1,0 +1,17 @@
+image: redis:6.2
+port: 6379
+resources:
+  requests:
+    cpu: "100m"
+    memory: "256Mi"
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+service:
+  type: ClusterIP
+  port: 6379
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/databases/values.yaml
+++ b/helm/ticket-booking/charts/databases/values.yaml
@@ -1,0 +1,9 @@
+mysql:
+  enabled: true
+  image: mysql:8.0
+  port: 3306
+  rootPassword: root
+redis:
+  enabled: true
+  image: redis:6.2
+  port: 6379

--- a/helm/ticket-booking/charts/discovery/Chart.yaml
+++ b/helm/ticket-booking/charts/discovery/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: discovery
+description: A Helm chart for deploying the discovery service
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ticket-booking/charts/discovery/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/discovery/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{/* Common labels */}} {{- define "discovery.labels" -}} app: discovery {{- end -}}
+
+{{/* Selector labels */}} {{- define "discovery.selectorLabels" -}} app: discovery {{- end -}}

--- a/helm/ticket-booking/charts/discovery/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/discovery/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: discovery
+  labels: { { - include "discovery.labels" . | nindent 4 } }
+spec:
+  replicas: { { .Values.replicas } }
+  selector:
+    matchLabels: { { - include "discovery.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "discovery.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: discovery
+          image: { { .Values.image } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/discovery/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/discovery/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: discovery
+  labels:
+    {{- include "discovery.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: discovery
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/discovery/templates/service.yaml
+++ b/helm/ticket-booking/charts/discovery/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: discovery
+  labels: { { - include "discovery.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "discovery.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/discovery/values.yaml
+++ b/helm/ticket-booking/charts/discovery/values.yaml
@@ -1,0 +1,18 @@
+image: sagiri2004/ticket-booking-discovery:latest
+replicas: 1
+port: 8761
+resources:
+  requests:
+    cpu: 400m
+    memory: 384Mi
+  limits:
+    cpu: 800m
+    memory: 768Mi
+service:
+  type: ClusterIP
+  port: 8761
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/gateway/Chart.yaml
+++ b/helm/ticket-booking/charts/gateway/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: gateway
+description: A Helm chart for deploying the API Gateway
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ticket-booking/charts/gateway/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/gateway/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Common labels
+*/}}
+{{- define "gateway.labels" -}}
+app: gateway
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gateway.selectorLabels" -}}
+app: gateway
+{{- end -}}

--- a/helm/ticket-booking/charts/gateway/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/gateway/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  labels: { { - include "gateway.labels" . | nindent 4 } }
+spec:
+  replicas: { { .Values.replicas } }
+  selector:
+    matchLabels: { { - include "gateway.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "gateway.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: gateway
+          image: { { .Values.image } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/gateway/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/gateway/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gateway
+  labels:
+    {{- include "gateway.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gateway
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/gateway/templates/service.yaml
+++ b/helm/ticket-booking/charts/gateway/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  labels: { { - include "gateway.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "gateway.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/gateway/values.yaml
+++ b/helm/ticket-booking/charts/gateway/values.yaml
@@ -1,0 +1,18 @@
+image: sagiri2004/ticket-booking-gateway:latest
+replicas: 1
+port: 8080
+resources:
+  requests:
+    cpu: "100m"
+    memory: "256Mi"
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+service:
+  type: ClusterIP
+  port: 8080
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/messaging/Chart.yaml
+++ b/helm/ticket-booking/charts/messaging/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: messaging
+description: A Helm chart for deploying messaging components (Kafka, Zookeeper)
+version: 0.1.0
+appVersion: "1.0.0"
+dependencies:
+  - name: kafka
+    version: 0.1.0
+    condition: kafka.enabled
+  - name: zookeeper
+    version: 0.1.0
+    condition: zookeeper.enabled

--- a/helm/ticket-booking/charts/messaging/charts/kafka/Chart.yaml
+++ b/helm/ticket-booking/charts/messaging/charts/kafka/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: kafka
+description: A Helm chart for deploying Kafka
+version: 0.1.0
+appVersion: "latest"

--- a/helm/ticket-booking/charts/messaging/charts/kafka/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/messaging/charts/kafka/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{/* Common labels */}} {{- define "kafka.labels" -}} app: kafka {{- end -}}
+
+{{/* Selector labels */}} {{- define "kafka.selectorLabels" -}} app: kafka {{- end -}}

--- a/helm/ticket-booking/charts/messaging/charts/kafka/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/messaging/charts/kafka/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  labels: { { - include "kafka.labels" . | nindent 4 } }
+spec:
+  replicas: { { .Values.replicas } }
+  selector:
+    matchLabels: { { - include "kafka.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "kafka.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: kafka
+          image: { { .Values.image } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/messaging/charts/kafka/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/messaging/charts/kafka/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: kafka
+  labels:
+    {{- include "kafka.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kafka
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/messaging/charts/kafka/templates/service.yaml
+++ b/helm/ticket-booking/charts/messaging/charts/kafka/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  labels: { { - include "kafka.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "kafka.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/messaging/charts/kafka/values.yaml
+++ b/helm/ticket-booking/charts/messaging/charts/kafka/values.yaml
@@ -1,0 +1,18 @@
+image: confluentinc/cp-kafka:latest
+port: 9092
+replicas: 1
+resources:
+  requests:
+    cpu: "200m"
+    memory: "512Mi"
+  limits:
+    cpu: "1000m"
+    memory: "1024Mi"
+service:
+  type: ClusterIP
+  port: 9092
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/messaging/charts/zookeeper/Chart.yaml
+++ b/helm/ticket-booking/charts/messaging/charts/zookeeper/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: zookeeper
+description: A Helm chart for deploying Zookeeper
+version: 0.1.0
+appVersion: "latest"

--- a/helm/ticket-booking/charts/messaging/charts/zookeeper/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/messaging/charts/zookeeper/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{/* Common labels */}} {{- define "zookeeper.labels" -}} app: zookeeper {{- end -}}
+
+{{/* Selector labels */}} {{- define "zookeeper.selectorLabels" -}} app: zookeeper {{- end -}}

--- a/helm/ticket-booking/charts/messaging/charts/zookeeper/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/messaging/charts/zookeeper/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zookeeper
+  labels: { { - include "zookeeper.labels" . | nindent 4 } }
+spec:
+  replicas: { { .Values.replicas } }
+  selector:
+    matchLabels: { { - include "zookeeper.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "zookeeper.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: zookeeper
+          image: { { .Values.image } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/messaging/charts/zookeeper/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/messaging/charts/zookeeper/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: zookeeper
+  labels:
+    {{- include "zookeeper.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: zookeeper
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/messaging/charts/zookeeper/templates/service.yaml
+++ b/helm/ticket-booking/charts/messaging/charts/zookeeper/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+  labels: { { - include "zookeeper.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "zookeeper.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/messaging/charts/zookeeper/values.yaml
+++ b/helm/ticket-booking/charts/messaging/charts/zookeeper/values.yaml
@@ -1,0 +1,18 @@
+image: confluentinc/cp-zookeeper:latest
+port: 2181
+replicas: 1
+resources:
+  requests:
+    cpu: "200m"
+    memory: "512Mi"
+  limits:
+    cpu: "1000m"
+    memory: "1024Mi"
+service:
+  type: ClusterIP
+  port: 2181
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/messaging/values.yaml
+++ b/helm/ticket-booking/charts/messaging/values.yaml
@@ -1,0 +1,8 @@
+kafka:
+  enabled: true
+  image: confluentinc/cp-kafka:latest
+  port: 9092
+zookeeper:
+  enabled: true
+  image: confluentinc/cp-zookeeper:latest
+  port: 2181

--- a/helm/ticket-booking/charts/services/Chart.yaml
+++ b/helm/ticket-booking/charts/services/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: services
+description: A Helm chart for deploying microservices
+version: 0.1.0
+appVersion: "1.0.0"
+dependencies:
+  - name: authentication
+    version: 0.1.0
+    condition: authentication.enabled
+  - name: booking
+    version: 0.1.0
+    condition: booking.enabled
+  - name: notification
+    version: 0.1.0
+    condition: notification.enabled
+  - name: test
+    version: 0.1.0
+    condition: test.enabled
+  - name: ticket
+    version: 0.1.0
+    condition: ticket.enabled
+  - name: user
+    version: 0.1.0
+    condition: user.enabled

--- a/helm/ticket-booking/charts/services/charts/authentication/Chart.yaml
+++ b/helm/ticket-booking/charts/services/charts/authentication/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: authentication
+description: A Helm chart for deploying the authentication microservice
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ticket-booking/charts/services/charts/authentication/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/services/charts/authentication/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Common labels
+*/}}
+{{- define "authentication.labels" -}}
+app: authentication
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "authentication.selectorLabels" -}}
+app: authentication
+{{- end -}}

--- a/helm/ticket-booking/charts/services/charts/authentication/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/services/charts/authentication/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authentication
+  labels: { { - include "authentication.labels" . | nindent 4 } }
+spec:
+  replicas: { { .Values.replicas } }
+  selector:
+    matchLabels: { { - include "authentication.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "authentication.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: authentication
+          image: { { .Values.image } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/services/charts/authentication/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/services/charts/authentication/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: authentication
+  labels:
+    {{- include "authentication.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: authentication
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/services/charts/authentication/templates/service.yaml
+++ b/helm/ticket-booking/charts/services/charts/authentication/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: authentication
+  labels: { { - include "authentication.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "authentication.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/services/charts/authentication/values.yaml
+++ b/helm/ticket-booking/charts/services/charts/authentication/values.yaml
@@ -1,0 +1,18 @@
+image: sagiri2004/ticket-booking-authentication:latest
+port: 9001
+replicas: 1
+resources:
+  requests:
+    cpu: 400m
+    memory: 384Mi
+  limits:
+    cpu: 800m
+    memory: 768Mi
+service:
+  type: ClusterIP
+  port: 9001
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/services/charts/booking/Chart.yaml
+++ b/helm/ticket-booking/charts/services/charts/booking/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: booking
+description: A Helm chart for deploying the booking microservice
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ticket-booking/charts/services/charts/booking/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/services/charts/booking/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{/* Common labels */}} {{- define "booking.labels" -}} app: booking {{- end -}}
+
+{{/* Selector labels */}} {{- define "booking.selectorLabels" -}} app: booking {{- end -}}

--- a/helm/ticket-booking/charts/services/charts/booking/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/services/charts/booking/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: booking
+  labels: { { - include "booking.labels" . | nindent 4 } }
+spec:
+  replicas: { { .Values.replicas } }
+  selector:
+    matchLabels: { { - include "booking.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "booking.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: booking
+          image: { { .Values.image } }
+          imagePullPolicy: { { .Values.global.imagePullPolicy } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/services/charts/booking/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/services/charts/booking/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: booking
+  labels:
+    {{- include "booking.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: booking
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/services/charts/booking/templates/service.yaml
+++ b/helm/ticket-booking/charts/services/charts/booking/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: booking
+  labels: { { - include "booking.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "booking.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/services/charts/booking/values.yaml
+++ b/helm/ticket-booking/charts/services/charts/booking/values.yaml
@@ -1,0 +1,18 @@
+image: sagiri2004/ticket-booking-booking:latest
+port: 9005
+replicas: 1
+resources:
+  requests:
+    cpu: 400m
+    memory: 384Mi
+  limits:
+    cpu: 800m
+    memory: 768Mi
+service:
+  type: ClusterIP
+  port: 9005
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/services/charts/notification/Chart.yaml
+++ b/helm/ticket-booking/charts/services/charts/notification/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: notification
+description: A Helm chart for deploying the notification microservice
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ticket-booking/charts/services/charts/notification/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/services/charts/notification/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Common labels
+*/}}
+{{- define "notification.labels" -}}
+app: notification
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "notification.selectorLabels" -}}
+app: notification
+{{- end -}}

--- a/helm/ticket-booking/charts/services/charts/notification/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/services/charts/notification/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification
+  labels: { { - include "notification.labels" . | nindent 4 } }
+spec:
+  replicas: { { .Values.replicas } }
+  selector:
+    matchLabels: { { - include "notification.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "notification.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: notification
+          image: { { .Values.image } }
+          imagePullPolicy: { { .Values.global.imagePullPolicy } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/services/charts/notification/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/services/charts/notification/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: notification
+  labels:
+    {{- include "notification.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: notification
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/services/charts/notification/templates/service.yaml
+++ b/helm/ticket-booking/charts/services/charts/notification/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification
+  labels: { { - include "notification.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "notification.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/services/charts/notification/values.yaml
+++ b/helm/ticket-booking/charts/services/charts/notification/values.yaml
@@ -1,0 +1,18 @@
+image: sagiri2004/ticket-booking-notification:latest
+port: 9006
+replicas: 1
+resources:
+  requests:
+    cpu: 400m
+    memory: 384Mi
+  limits:
+    cpu: 800m
+    memory: 768Mi
+service:
+  type: ClusterIP
+  port: 9006
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/services/charts/test/Chart.yaml
+++ b/helm/ticket-booking/charts/services/charts/test/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: test
+description: A Helm chart for deploying the test microservice
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ticket-booking/charts/services/charts/test/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/services/charts/test/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Common labels
+*/}}
+{{- define "test.labels" -}}
+app: test
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "test.selectorLabels" -}}
+app: test
+{{- end -}}

--- a/helm/ticket-booking/charts/services/charts/test/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/services/charts/test/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+  labels: { { - include "test.labels" . | nindent 4 } }
+spec:
+  replicas: { { .Values.replicas } }
+  selector:
+    matchLabels: { { - include "test.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "test.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: test
+          image: { { .Values.image } }
+          imagePullPolicy: { { .Values.global.imagePullPolicy } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/services/charts/test/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/services/charts/test/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: test
+  labels:
+    {{- include "test.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: test
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/services/charts/test/templates/service.yaml
+++ b/helm/ticket-booking/charts/services/charts/test/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+  labels: { { - include "test.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "test.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/services/charts/test/values.yaml
+++ b/helm/ticket-booking/charts/services/charts/test/values.yaml
@@ -1,0 +1,18 @@
+image: sagiri2004/ticket-booking-test:latest
+port: 9003
+replicas: 1
+resources:
+  requests:
+    cpu: 400m
+    memory: 384Mi
+  limits:
+    cpu: 800m
+    memory: 768Mi
+service:
+  type: ClusterIP
+  port: 9003
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/services/charts/ticket/Chart.yaml
+++ b/helm/ticket-booking/charts/services/charts/ticket/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: ticket
+description: A Helm chart for deploying the ticket microservice
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ticket-booking/charts/services/charts/ticket/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/services/charts/ticket/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Common labels
+*/}}
+{{- define "ticket.labels" -}}
+app: ticket
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ticket.selectorLabels" -}}
+app: ticket
+{{- end -}}

--- a/helm/ticket-booking/charts/services/charts/ticket/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/services/charts/ticket/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ticket
+  labels: { { - include "ticket.labels" . | nindent 4 } }
+spec:
+  replicas: { { .Values.replicas } }
+  selector:
+    matchLabels: { { - include "ticket.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "ticket.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: ticket
+          image: { { .Values.image } }
+          imagePullPolicy: { { .Values.global.imagePullPolicy } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/services/charts/ticket/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/services/charts/ticket/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ticket
+  labels:
+    {{- include "ticket.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ticket
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/services/charts/ticket/templates/service.yaml
+++ b/helm/ticket-booking/charts/services/charts/ticket/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ticket
+  labels: { { - include "ticket.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "ticket.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/services/charts/ticket/values.yaml
+++ b/helm/ticket-booking/charts/services/charts/ticket/values.yaml
@@ -1,0 +1,18 @@
+image: sagiri2004/ticket-booking-ticket:latest
+port: 9004
+replicas: 1
+resources:
+  requests:
+    cpu: 400m
+    memory: 384Mi
+  limits:
+    cpu: 800m
+    memory: 768Mi
+service:
+  type: ClusterIP
+  port: 9004
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/services/charts/user/Chart.yaml
+++ b/helm/ticket-booking/charts/services/charts/user/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: user
+description: A Helm chart for deploying the user microservice
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ticket-booking/charts/services/charts/user/templates/_helpers.tpl
+++ b/helm/ticket-booking/charts/services/charts/user/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Common labels
+*/}}
+{{- define "user.labels" -}}
+app: user
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "user.selectorLabels" -}}
+app: user
+{{- end -}}

--- a/helm/ticket-booking/charts/services/charts/user/templates/deployment.yaml
+++ b/helm/ticket-booking/charts/services/charts/user/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user
+  labels: { { - include "user.labels" . | nindent 4 } }
+spec:
+  replicas: { { .Values.replicas } }
+  selector:
+    matchLabels: { { - include "user.selectorLabels" . | nindent 6 } }
+  template:
+    metadata:
+      labels: { { - include "user.selectorLabels" . | nindent 8 } }
+    spec:
+      containers:
+        - name: user
+          image: { { .Values.image } }
+          imagePullPolicy: { { .Values.global.imagePullPolicy } }
+          ports:
+            - containerPort: { { .Values.port } }
+          resources: { { - toYaml .Values.resources | nindent 10 } }

--- a/helm/ticket-booking/charts/services/charts/user/templates/hpa.yaml
+++ b/helm/ticket-booking/charts/services/charts/user/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: user
+  labels:
+    {{- include "user.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: user
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ticket-booking/charts/services/charts/user/templates/service.yaml
+++ b/helm/ticket-booking/charts/services/charts/user/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: user
+  labels: { { - include "user.labels" . | nindent 4 } }
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: { { .Values.port } }
+      protocol: TCP
+  selector: { { - include "user.selectorLabels" . | nindent 4 } }

--- a/helm/ticket-booking/charts/services/charts/user/values.yaml
+++ b/helm/ticket-booking/charts/services/charts/user/values.yaml
@@ -1,0 +1,18 @@
+image: sagiri2004/ticket-booking-user:latest
+port: 9002
+replicas: 1
+resources:
+  requests:
+    cpu: 400m
+    memory: 384Mi
+  limits:
+    cpu: 800m
+    memory: 768Mi
+service:
+  type: ClusterIP
+  port: 9002
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80

--- a/helm/ticket-booking/charts/services/values.yaml
+++ b/helm/ticket-booking/charts/services/values.yaml
@@ -1,0 +1,24 @@
+authentication:
+  enabled: true
+  image: sagiri2004/ticket-booking-authentication:latest
+  port: 8081
+booking:
+  enabled: true
+  image: sagiri2004/ticket-booking-booking:latest
+  port: 8082
+notification:
+  enabled: true
+  image: sagiri2004/ticket-booking-notification:latest
+  port: 8083
+test:
+  enabled: true
+  image: sagiri2004/ticket-booking-test:latest
+  port: 8084
+ticket:
+  enabled: true
+  image: sagiri2004/ticket-booking-ticket:latest
+  port: 8085
+user:
+  enabled: true
+  image: sagiri2004/ticket-booking-user:latest
+  port: 8086

--- a/helm/ticket-booking/values.yaml
+++ b/helm/ticket-booking/values.yaml
@@ -1,0 +1,102 @@
+# Default values for ticket-booking chart
+
+# Enable/disable components
+axon:
+  enabled: true
+databases:
+  enabled: true
+messaging:
+  enabled: true
+discovery:
+  enabled: true
+gateway:
+  enabled: true
+services:
+  enabled: true
+
+# Global configurations
+global:
+  imagePullPolicy: IfNotPresent
+  namespace: ticket-booking
+
+# Axon configuration
+axon:
+  image: axoniq/axonserver:latest
+  replicas: 1
+  port: 8024
+
+# Databases configuration
+databases:
+  mysql:
+    enabled: true
+    image: mysql:8.0
+    port: 3306
+    rootPassword: example
+  redis:
+    enabled: true
+    image: redis:6.2
+    port: 6379
+
+# Messaging configuration
+messaging:
+  kafka:
+    enabled: true
+    image: confluentinc/cp-kafka:latest
+    port: 9092
+  zookeeper:
+    enabled: true
+    image: confluentinc/cp-zookeeper:latest
+    port: 2181
+
+# Discovery configuration
+discovery:
+  image: sagiri2004/ticket-booking-discovery:latest
+  replicas: 1
+  port: 8761
+
+# Gateway configuration
+gateway:
+  image: sagiri2004/ticket-booking-gateway:latest
+  replicas: 1
+  port: 8080
+
+# Services configuration
+services:
+  authentication:
+    enabled: true
+    image: sagiri2004/ticket-booking-authentication:latest
+    port: 9001
+    replicas: 1
+  booking:
+    enabled: true
+    image: sagiri2004/ticket-booking-booking:latest
+    port: 9005
+    replicas: 1
+  notification:
+    enabled: true
+    image: sagiri2004/ticket-booking-notification:latest
+    port: 9006
+    replicas: 1
+  test:
+    enabled: false
+    image: sagiri2004/ticket-booking-test:latest
+    port: 9003
+    replicas: 1
+  ticket:
+    enabled: true
+    image: sagiri2004/ticket-booking-ticket:latest
+    port: 9004
+    replicas: 1
+  user:
+    enabled: true
+    image: sagiri2004/ticket-booking-user:latest
+    port: 9002
+    replicas: 1
+
+# Placeholder for monitoring (to be added later)
+monitoring:
+  enabled: false
+  prometheus:
+    enabled: false
+  grafana:
+    enabled: false


### PR DESCRIPTION
…covery, gateway, services, monitoring), sub-subcharts (kafka, zookeeper, mysql, redis, authentication, booking, notification, test, ticket, user), including Chart.yaml, values.yaml, _helpers.tpl, and templates (deployment.yaml, service.yaml, hpa.yaml) for ticket-booking project